### PR TITLE
Introduce user migration feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,12 @@
             <artifactId>hutool-all</artifactId>
             <version>5.8.18</version>
         </dependency>
-    </dependencies>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+      </dependencies>
 
     <build>
         <plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,15 +1,9 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-
-#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-#spring.jpa.defer-datasource-initialization=true
-
-#spring.sql.init.mode=always
+spring.datasource.url=jdbc:mysql://localhost:3306/test?allowMultiQueries=true
+spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=root
 
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto= update
 
-spring.h2.console.enabled=true


### PR DESCRIPTION
This pull request introduces changes to migrate the application from an H2 in-memory database to a MySQL database. It includes updates to dependencies, configuration files, and the `UserController` class to support database migration functionality. The most important changes are grouped below by theme.

### Database Migration Setup:
* Added `mysql-connector-j` dependency in `pom.xml` to enable MySQL database connectivity.
* Updated `application.properties` to replace H2 database configuration with MySQL configuration, including connection URL, driver class, username, and password.

### Controller Enhancements:
* Introduced a new endpoint `/user/migrate` in `UserController` to handle user migration from the old schema to the new schema, including rollback functionality using savepoints.
* Added `EntityManager` and utility methods (`getConnection` and `doMigrateUser`) in `UserController` to manage database connections and perform user migration operations. [[1]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR46-R48) [[2]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR115-R150)

### Additional Imports:
* Added imports for MySQL-specific classes (`ConnectionImpl`, `Savepoint`) and other utilities (`AtomicReference`) in `UserController`. [[1]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR10-R11) [[2]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR30-R33)