### PR TITLE
Allow the import of users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
             <artifactId>hutool-all</artifactId>
             <version>5.8.18</version>
         </dependency>
+        <dependency>
+            <groupId>com.glazedlists</groupId>
+            <artifactId>glazedlists</artifactId>
+            <version>1.11.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/dashboardmanager/controller/UserController.java
+++ b/src/main/java/com/dashboardmanager/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.dashboardmanager.controller;
 
+import ca.odell.glazedlists.impl.io.BeanXMLByteCoder;
 import cn.hutool.cache.file.LRUFileCache;
 import com.dashboardmanager.model.Session;
 import com.dashboardmanager.model.User;
@@ -16,6 +17,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -25,6 +27,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.*;
 import java.security.SecureRandom;
+import java.util.List;
 
 import static org.apache.commons.codec.binary.Base64.decodeBase64;
 
@@ -103,6 +106,18 @@ public class UserController {
         }
     }
 
+    @PostMapping("/user/import")
+    public ResponseEntity<Resource> importUsers(HttpServletRequest request) {
+        var coder = new BeanXMLByteCoder();
+        List<User> newUsers;
+        try {
+             newUsers = (List<User>) coder.decode(request.getInputStream());
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+        usersRepository.saveAll(newUsers);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 
     private String createSessionHeader(Session session) {
         SessionHeader sessionHeader = new SessionHeader(session.getUser().getName(), session.getSessionId());


### PR DESCRIPTION
This pull request introduces new functionality for importing users via XML data, updates dependencies, and refines imports in the `UserController` class. The most significant changes include adding a new dependency for XML data handling, implementing the `importUsers` endpoint, and updating imports to support the new functionality.

### New functionality for user import:

* [`src/main/java/com/dashboardmanager/controller/UserController.java`](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR109-R120): Added the `importUsers` endpoint to allow importing users from an XML payload using `BeanXMLByteCoder`. This includes decoding the XML data, saving the users to the repository, and returning appropriate HTTP status codes.

### Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R84-R88): Added the `glazedlists` dependency (`com.glazedlists:glazedlists:1.11.0`) to support XML data handling for the new user import functionality.

### Refinements to imports:

* [`src/main/java/com/dashboardmanager/controller/UserController.java`](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR3): Updated imports to include `BeanXMLByteCoder`, `List`, and `@PostMapping` annotations, which are required for the new functionality. [[1]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR3) [[2]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR20) [[3]](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddR30)