### PR TITLE
replacing decodeBase64

### DIFF
--- a/src/main/java/com/dashboardmanager/controller/UserController.java
+++ b/src/main/java/com/dashboardmanager/controller/UserController.java
@@ -26,7 +26,7 @@ import org.springframework.web.servlet.view.RedirectView;
 import java.io.*;
 import java.security.SecureRandom;
 
-import static org.apache.commons.codec.binary.Base64.decodeBase64;
+import java.util.Base64;
 
 @RestController
 public class UserController {
@@ -122,7 +122,7 @@ public class UserController {
         String sessionAuth = request.getHeader("Session-Auth");
         if (sessionAuth != null) {
             try {
-                byte[] decoded = decodeBase64(sessionAuth);
+                byte[] decoded = Base64.getDecoder().decode(sessionAuth);
                 ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(decoded));
                 return (SessionHeader) in.readObject();
             } catch (Exception e) {


### PR DESCRIPTION
This pull request updates the `UserController` class to replace the usage of `org.apache.commons.codec.binary.Base64` with `java.util.Base64`. This change simplifies the codebase and aligns it with modern Java practices by using the built-in `Base64` class.

### Codebase simplification:

* [`src/main/java/com/dashboardmanager/controller/UserController.java`](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddL29-R29): Replaced the import of `org.apache.commons.codec.binary.Base64` with `java.util.Base64`.
* [`src/main/java/com/dashboardmanager/controller/UserController.java`](diffhunk://#diff-3c9d66f0223bb4fbb5839e31cd18f91cda953db37cce8ee44a181e073a2c88ddL125-R125): Updated the `getSessionHeader` method to use `Base64.getDecoder().decode(sessionAuth)` instead of `decodeBase64(sessionAuth)` for decoding.